### PR TITLE
Add a `mix sql_fmt.format` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ end
 
 Documentation can be found at [https://hexdocs.pm/sql_fmt](https://hexdocs.pm/sql_fmt).
 
-## Example Output
+## Usage
 
-After setting up SqlFmt in your application you can use the SqlFmt functions in order to format queries. Here are a
+After setting up `SqlFmt` in your application you can use the `SqlFmt` functions in order to format queries. Here are a
 couple examples of queries with having parameters inline and with passing in the parameters separately:
 
 ```elixir
@@ -88,6 +88,27 @@ WHERE
 
 Be sure to checkout the HexDocs as you can also provide formatting options to the functions to tailor the output to your
 liking.
+
+## Mix task
+
+A `mix sql_fmt.format` task is provided that can be used in order to
+format a set of files, similarly to `mix format`.
+
+```bash
+# you can pass one or more paths or patterns to be formatted
+$ mix sql_fmt.format query.sql "sql/**/*.sql.ex"
+
+# you can pass the --check-formatted option to make it raise if any
+# file is not formatted
+$ mix sql_fmt.format --check-formatted "sql/**/*.sql.ex"
+```
+
+For more details on the supported options check the help:
+
+```bash
+$ mix help sql_fmt.format
+```
+
 
 ## Supporting SqlFmt
 

--- a/lib/mix/tasks/format.ex
+++ b/lib/mix/tasks/format.ex
@@ -1,0 +1,152 @@
+defmodule Mix.Tasks.SqlFmt.Format do
+  @shortdoc "Formats the given SQL files"
+
+  @moduledoc """
+  Formats the given files and patterns.
+
+      $ mix sql_fmt.format query.sql "sql/**/*.sql"
+
+  ## Options
+
+  The following CLI options are supported:
+
+  * `--check-formatted` - checks that the file is already formatted.
+    This is useful in pre-commit hooks and CI scripts if you want to
+    reject contributions with unformatted SQL code. If the check fails,
+    the formatted contents are not written to disk.
+
+  * `--indent` – specifies how many spaces are used for indents.
+    Defaults to `2`.
+
+  * `--no-uppercase` – if set SQL reserved words will not be capitalized.
+
+  * `--lines-between-queries` – specifies how many line breaks should be
+    present after a query. Defaults to `1`.
+
+  * `--ignore-case-convert` – comma separated list of strings that should
+    not be case converted. If not set all reserved keywords are capitalized.
+  """
+
+  use Mix.Task
+
+  @switches [
+    check_formatted: :boolean,
+    indent: :integer,
+    no_uppercase: :boolean,
+    lines_between_queries: :integer,
+    ignore_case_convert: :string
+  ]
+
+  @impl true
+  def run(args) do
+    {opts, paths} = OptionParser.parse!(args, strict: @switches)
+
+    files = expand_paths(paths)
+
+    files
+    |> Task.async_stream(&format_file(&1, opts), ordered: false, timeout: :infinity)
+    |> Enum.reduce({[], []}, &collect_status/2)
+    |> check!()
+  end
+
+  defp parse_ignore_case_convert(nil), do: []
+  defp parse_ignore_case_convert(ignore), do: String.split(ignore, ",")
+
+  defp expand_paths([]) do
+    Mix.raise("Expected one or more files/patterns to be given to mix sql_fmt.format")
+  end
+
+  defp expand_paths(files_and_patterns) do
+    files =
+      for file_or_pattern <- files_and_patterns,
+          file <- matching_files(file_or_pattern),
+          uniq: true,
+          do: file
+
+    if files == [] do
+      Mix.raise(
+        "Could not find a file to format. The files/patterns given to command line " <>
+          "did not point to any existing file. Got: #{inspect(files_and_patterns)}"
+      )
+    end
+
+    files
+  end
+
+  defp matching_files(path) do
+    path
+    |> Path.expand()
+    |> Path.wildcard(match_dot: true)
+    |> Enum.filter(&File.regular?/1)
+  end
+
+  defp format_file(file, opts) do
+    input = File.read!(file)
+
+    formatter_opts = [
+      indent: opts[:indent] || 2,
+      uppercase: !opts[:no_uppercase],
+      lines_between_queries: opts[:lines_between_queries] || 1,
+      ignore_case_convert: parse_ignore_case_convert(opts[:ignore_case_convert])
+    ]
+
+    {:ok, output} = SqlFmt.format_query(input, formatter_opts)
+
+    check_formatted? = Keyword.get(opts, :check_formatted, false)
+
+    cond do
+      check_formatted? ->
+        if input == output, do: :ok, else: {:not_formatted, {file, input, output}}
+
+      true ->
+        File.write!(file, output)
+    end
+  rescue
+    exception ->
+      {:exit, file, exception, __STACKTRACE__}
+  end
+
+  defp collect_status({:ok, :ok}, acc), do: acc
+
+  defp collect_status({:ok, {:exit, _, _, _} = exit}, {exits, not_formatted}) do
+    {[exit | exits], not_formatted}
+  end
+
+  defp collect_status({:ok, {:not_formatted, file}}, {exits, not_formatted}) do
+    {exits, [file | not_formatted]}
+  end
+
+  defp check!({[], []}), do: :ok
+
+  defp check!({[{:exit, file, exception, stacktrace} | _], _not_formatted}) do
+    Mix.shell().error("mix sql_fmt.format failed for file: #{Path.relative_to_cwd(file)}")
+    reraise exception, stacktrace
+  end
+
+  defp check!({_exits, [_ | _] = not_formatted}) do
+    files =
+      Enum.map(not_formatted, fn {file, _input, _output} ->
+        file = Path.relative_to_cwd(file, force: true)
+
+        [
+          IO.ANSI.bright(),
+          IO.ANSI.red(),
+          "* ",
+          file,
+          IO.ANSI.reset()
+        ]
+      end)
+      |> Enum.join("\n")
+
+    message = """
+    The following files are not formatted:
+
+    #{files}
+    """
+
+    Mix.raise("""
+    mix sql_fmt.format failed due to --check-formatted.
+    #{message}
+    """)
+  end
+end

--- a/test/mix/tasks/format_test.exs
+++ b/test/mix/tasks/format_test.exs
@@ -1,0 +1,159 @@
+defmodule Mix.Tasks.SqlFmt.FormatTest do
+  use ExUnit.Case, async: true
+
+  test "formats matching files", context do
+    in_tmp(context.test, fn ->
+      sql_fixture("query.sql")
+
+      Mix.Tasks.SqlFmt.Format.run(["query.sql"])
+      assert File.read!("query.sql") == "SELECT\n  *\nFROM\n  users"
+    end)
+  end
+
+  test "with --indent set", context do
+    in_tmp(context.test, fn ->
+      sql_fixture("query.sql")
+
+      Mix.Tasks.SqlFmt.Format.run(["query.sql", "--indent", "4"])
+      assert File.read!("query.sql") == "SELECT\n    *\nFROM\n    users"
+    end)
+  end
+
+  test "with --no-uppercase set", context do
+    in_tmp(context.test, fn ->
+      sql_fixture("query.sql")
+
+      Mix.Tasks.SqlFmt.Format.run(["query.sql", "--no-uppercase"])
+      assert File.read!("query.sql") == "select\n  *\nfrom\n  users"
+    end)
+  end
+
+  test "with multiple queries", context do
+    in_tmp(context.test, fn ->
+      content = "select * from users; select * from groups;"
+      sql_fixture("query.sql", content)
+
+      Mix.Tasks.SqlFmt.Format.run(["query.sql"])
+
+      assert File.read!("query.sql") ==
+               """
+               SELECT
+                 *
+               FROM
+                 users;
+               SELECT
+                 *
+               FROM
+                 groups;\
+               """
+
+      # with --lines-between-queries set
+      Mix.Tasks.SqlFmt.Format.run(["query.sql", "--lines-between-queries", "3"])
+
+      assert File.read!("query.sql") ==
+               """
+               SELECT
+                 *
+               FROM
+                 users;
+
+
+               SELECT
+                 *
+               FROM
+                 groups;\
+               """
+    end)
+  end
+
+  test "with --ignore-case-convert set", context do
+    in_tmp(context.test, fn ->
+      sql_fixture("query.sql", "select * from users where age > 18;")
+
+      Mix.Tasks.SqlFmt.Format.run(["query.sql", "--ignore-case-convert", "select,where"])
+      assert File.read!("query.sql") == "select\n  *\nFROM\n  users\nwhere\n  age > 18;"
+
+      Mix.Tasks.SqlFmt.Format.run(["query.sql", "--ignore-case-convert", "select"])
+      assert File.read!("query.sql") == "select\n  *\nFROM\n  users\nWHERE\n  age > 18;"
+    end)
+  end
+
+  test "with wildcards and multiple patterns", context do
+    in_tmp(context.test, fn ->
+      sql_fixture("sql/path_a/query.sql")
+      sql_fixture("sql/path_a/query2.sql")
+      sql_fixture("sql/path_b/query.sql")
+      sql_fixture("queries/query.sql")
+
+      Mix.Tasks.SqlFmt.Format.run(["sql/**/*.sql", "queries/query.sql"])
+      assert File.read!("sql/path_a/query.sql") == "SELECT\n  *\nFROM\n  users"
+      assert File.read!("sql/path_a/query2.sql") == "SELECT\n  *\nFROM\n  users"
+      assert File.read!("sql/path_b/query.sql") == "SELECT\n  *\nFROM\n  users"
+      assert File.read!("queries/query.sql") == "SELECT\n  *\nFROM\n  users"
+    end)
+  end
+
+  test "checks if file is formatted with --check-formatted", context do
+    in_tmp(context.test, fn ->
+      sql_fixture("query.sql")
+
+      assert_raise Mix.Error, ~r"mix sql_fmt.format failed due to --check-formatted", fn ->
+        Mix.Tasks.SqlFmt.Format.run(["query.sql", "--check-formatted"])
+      end
+
+      # the file has not changed
+      assert File.read!("query.sql") == "select * from users"
+
+      # format it and run with --check-formatted again
+      assert Mix.Tasks.SqlFmt.Format.run(["query.sql"]) == :ok
+      assert Mix.Tasks.SqlFmt.Format.run(["query.sql", "--check-formatted"]) == :ok
+
+      assert File.read!("query.sql") == "SELECT\n  *\nFROM\n  users"
+    end)
+  end
+
+  test "raises on invalid arguments", context do
+    in_tmp(context.test, fn ->
+      assert_raise Mix.Error, ~r"Expected one or more files\/patterns to be given", fn ->
+        Mix.Tasks.SqlFmt.Format.run([])
+      end
+
+      assert_raise Mix.Error, ~r"Could not find a file to format", fn ->
+        Mix.Tasks.SqlFmt.Format.run(["unknown.whatever"])
+      end
+    end)
+  end
+
+  test "raises for invalid files", context do
+    in_tmp(context.test, fn ->
+      # create a corrupt file to make it fail 
+      sql_fixture("query.sql", <<255, 255>>)
+
+      assert_raise ArgumentError, fn ->
+        Mix.Tasks.SqlFmt.Format.run(["*.sql"])
+      end
+
+      assert_received {:mix_shell, :error, ["mix sql_fmt.format failed for file: query.sql"]}
+    end)
+  end
+
+  def in_tmp(which, function) do
+    path = tmp_path(which)
+    File.rm_rf!(path)
+    File.mkdir_p!(path)
+    File.cd!(path, function)
+  end
+
+  defp tmp_path(path), do: Path.join("../tmp", remove_colons(path)) |> Path.expand()
+
+  defp remove_colons(term) do
+    term
+    |> to_string()
+    |> String.replace(":", "")
+  end
+
+  defp sql_fixture(path, query \\ "select * from users") do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, query)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,4 @@
+Mix.shell(Mix.Shell.Process)
+Application.put_env(:mix, :colors, enabled: false)
+
 ExUnit.start()


### PR DESCRIPTION
Similar to `mix format` but for SQL queries 😄 . 

<img width="820" alt="image" src="https://github.com/user-attachments/assets/bd6327ae-9ac0-4ca0-be6a-4acb5fd8e220">

The code is mostly "stolen" from `mix format`. We already use `pgformatter` in our CI pipelines, we could replace it with this.

If you are ok with adding the mix task, I will add tests and CLI flags for the supported formatting options.