### PR TITLE
dk-run_character_replacement_on_rust_side

### DIFF
--- a/lib/sql_fmt.ex
+++ b/lib/sql_fmt.ex
@@ -19,9 +19,7 @@ defmodule SqlFmt do
   def format_query(query, fmt_opts \\ []) do
     format_options = FormatOptions.new(fmt_opts)
 
-    query
-    |> Native.format(format_options)
-    |> maybe_clean_special_character_operators()
+    Native.format(query, format_options)
   end
 
   @doc """
@@ -39,38 +37,6 @@ defmodule SqlFmt do
   def format_query_with_params(query, query_params, fmt_opts \\ []) do
     format_options = FormatOptions.new(fmt_opts)
 
-    query
-    |> Native.format(query_params, format_options)
-    |> maybe_clean_special_character_operators()
-  end
-
-  # ---- Private helper functions ----
-
-  @special_character_sequence_regex ~r/(\+|\-|\*|\/|\<|\>|\=|\~|\!|\@|\#|\%|\^|\&|\||\`|\?)\s(\+|\-|\*|\/|\<|\>|\=|\~|\!|\@|\#|\%|\^|\&|\||\`|\?)/
-
-  # This is a work around the following bug in the Rust formatting
-  # library https://github.com/shssoichiro/sqlformat-rs/issues/52
-  #
-  # 63 Regex replacement passes has been chosen as it is the default max
-  # operator name as per the Postgres docs https://www.postgresql.org/docs/current/sql-createoperator.html.
-  # The function will break early if no more replacements need to occur though.
-  defp maybe_clean_special_character_operators({:ok, formatted_query}) do
-    post_processed_query =
-      1..63
-      |> Enum.reduce_while(formatted_query, fn _pass, acc ->
-        new_string = Regex.replace(@special_character_sequence_regex, acc, "\\g{1}\\g{2}")
-
-        if acc == new_string do
-          {:halt, new_string}
-        else
-          {:cont, new_string}
-        end
-      end)
-
-    {:ok, post_processed_query}
-  end
-
-  defp maybe_clean_special_character_operators(other) do
-    other
+    Native.format(query, query_params, format_options)
   end
 end

--- a/native/sql_fmt_nif/Cargo.lock
+++ b/native/sql_fmt_nif/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +130,8 @@ dependencies = [
 name = "sql_fmt_nif"
 version = "0.2.0"
 dependencies = [
+ "lazy_static",
+ "regex",
  "rustler",
  "sqlformat",
 ]

--- a/native/sql_fmt_nif/Cargo.toml
+++ b/native/sql_fmt_nif/Cargo.toml
@@ -10,6 +10,8 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+lazy_static = "1.5.0"
+regex = "1.6.0"
 rustler = "0.34.0"
 sqlformat = "0.3.0"
 

--- a/native/sql_fmt_nif/src/lib.rs
+++ b/native/sql_fmt_nif/src/lib.rs
@@ -45,10 +45,10 @@ fn format(sql_query: String, format_options: ElixirFormatOptions) -> StringResul
     let formatted_sql = sqlformat::format(sql_query.as_str(), &QueryParams::None, &options);
     let post_process_query = post_process_query(formatted_sql);
 
-    return StringResultTuple {
+    StringResultTuple {
         lhs: atoms::ok(),
-        rhs: post_process_query.to_string(),
-    };
+        rhs: post_process_query,
+    }
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
@@ -71,10 +71,10 @@ fn format(
     );
     let post_process_query = post_process_query(formatted_sql);
 
-    return StringResultTuple {
+    StringResultTuple {
         lhs: atoms::ok(),
-        rhs: post_process_query.to_string(),
-    };
+        rhs: post_process_query,
+    }
 }
 
 // ---- Private helper functions ----

--- a/native/sql_fmt_nif/src/lib.rs
+++ b/native/sql_fmt_nif/src/lib.rs
@@ -1,6 +1,13 @@
+use lazy_static::lazy_static;
+use regex::Regex;
 use rustler::Atom;
 use rustler::NifStruct;
 use rustler::NifTuple;
+
+lazy_static! {
+    static ref OPERATOR_REGEX: Regex =
+        Regex::new(r"([+\-*/<=>\~!@#%^&|`?])\s([+\-*/<=>\~!@#%^&|`?])").unwrap();
+}
 
 use sqlformat::{FormatOptions, Indent, QueryParams};
 
@@ -36,10 +43,11 @@ fn format(sql_query: String, format_options: ElixirFormatOptions) -> StringResul
     };
 
     let formatted_sql = sqlformat::format(sql_query.as_str(), &QueryParams::None, &options);
+    let post_process_query = post_process_query(formatted_sql);
 
     return StringResultTuple {
         lhs: atoms::ok(),
-        rhs: formatted_sql.to_string(),
+        rhs: post_process_query.to_string(),
     };
 }
 
@@ -61,11 +69,39 @@ fn format(
         &QueryParams::Indexed(query_params),
         &options,
     );
+    let post_process_query = post_process_query(formatted_sql);
 
     return StringResultTuple {
         lhs: atoms::ok(),
-        rhs: formatted_sql.to_string(),
+        rhs: post_process_query.to_string(),
     };
+}
+
+// ---- Private helper functions ----
+
+// This is a work around the following bug in the Rust formatting
+// library https://github.com/shssoichiro/sqlformat-rs/issues/52
+//
+// 63 Regex replacement passes has been chosen as it is the default max
+// operator name as per the Postgres docs https://www.postgresql.org/docs/current/sql-createoperator.html.
+// The function will break early if no more replacements need to occur though.
+
+fn post_process_query(formatted_query: String) -> String {
+    let mut current_string = formatted_query;
+
+    for _ in 0..63 {
+        let new_string = OPERATOR_REGEX
+            .replace_all(&current_string, "$1$2")
+            .to_string();
+
+        if current_string == new_string {
+            return new_string;
+        }
+
+        current_string = new_string;
+    }
+
+    current_string
 }
 
 rustler::init!("Elixir.SqlFmt.Native");


### PR DESCRIPTION
I know it’s a micro-optimization, but I formatted multiple queries in a row, and it was a bit slow. So, I added logs and saw that postprocessing the regex in Elixir almost doubles the time. Postprocessing it in Rust is 10 times faster. Claude also suggested updating the regex a bit.
```
SQL formatting took in rust 479.101µs
SQL formatting took in elixir with nif call 1758
SQL formatting full in elixir with nif and regex 2695
```
I did move the replacement to rust and it's much more performant:
```
SQL formatting took in rust 442.874µs
SQL formatting with post_process_query in rust took 575.504µs
SQL formatting total 1867
``` 